### PR TITLE
ENG-163921: add sidekiq_delegate tests and small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Gemfile.lock
 .idea/
 # rspec failure tracking
 .rspec_status
+.byebug_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
-## [Unreleased]
+## [0.2.0]
+
+### Added 
+
+- Full rspec coverage
+
+### Changed
+
+- Modified Method::WithArgs module to support splatted arguments, and privatized what should be non-public methods
+- Modified SidekiqDelegate::Job#perform_bulk to allow for yield to return nil or an array of Method::WithArgs, adding flexibility when bulk enqueueing using the "single loop" functionality.
+- Removed unnecessary complexity in SidekiqDelegate::Validator by consolidating the validation into a single (non-redundant) method: validate_delegate!
+- Modified sidekiq gem version reqs. to allow for broader range of versions.
+
+## [0.1.2]
+
+- Require sidekiq pro as dependency to avoid load race condition
 
 ## [0.1.0] - 2022-12-15
 
 - Initial release
 
-## [0.1.2]
-
-- Require sidekiq pro as dependency to avoid load race condition
+## [Unreleased]

--- a/lib/sidekiq_delegate/validator.rb
+++ b/lib/sidekiq_delegate/validator.rb
@@ -6,20 +6,11 @@ module SidekiqDelegate
         raise SidekiqDelegate::Error::DelegateError, "#{name}##{__method__} delegate must be a Method::WithArgs"
       end
 
-      validate_delegate_receiver!(method_with_args)
-    end
-    module_function :validate_delegate!
-
-    def validate_delegate_receiver!(method)
-      unless method.is_a?(Method)
-        raise SidekiqDelegate::Error::DelegateError, "#{name}##{__method__} delegate must be a method"
-      end
-
-      return if method.receiver.is_a?(Class)
+      return if method_with_args.receiver.is_a?(Class)
 
       raise SidekiqDelegate::Error::DelegateError, "#{name}##{__method__} delegate must be a class method"
     end
-    module_function :validate_delegate_receiver!
+    module_function :validate_delegate!
 
   end
 end

--- a/lib/sidekiq_delegate/version.rb
+++ b/lib/sidekiq_delegate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqDelegate
-  VERSION = '0.1.2'
+  VERSION = '0.2.0'
 end

--- a/sidekiq_delegate.gemspec
+++ b/sidekiq_delegate.gemspec
@@ -30,7 +30,12 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'sidekiq', '~> 5.2'
-  spec.add_dependency 'sidekiq-pro', '~> 5.0.0'
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "byebug"
+  spec.add_development_dependency "faker"
+
+  spec.add_dependency 'sidekiq', '>= 5.2', '< 7.0.0'
+  spec.add_dependency 'sidekiq-pro', '~> 5.0'
 
 end

--- a/spec/batch/contained_job_spec.rb
+++ b/spec/batch/contained_job_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe SidekiqDelegate::Batch::ContainedJob do
+
+  subject(:job_klass) do
+    Object.const_set(
+      Faker::Lorem.word.capitalize,
+      Class.new do
+        include SidekiqDelegate::Batch::ContainedJob
+      end
+    )
+  end
+
+  context 'server_actions' do
+    subject { job_klass.new }
+
+    it 'should call_delegate if it is valid_within_batch?' do
+      batch = double
+      options = double
+      allow(subject).to receive(:valid_within_batch?).and_return(true)
+
+      expect(subject).to receive(:batch).and_return(batch)
+      expect(batch).to receive(:jobs).and_yield
+
+      subject.perform(options)
+    end
+  end
+
+end

--- a/spec/batch/job_spec.rb
+++ b/spec/batch/job_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe SidekiqDelegate::Batch::Job do
+
+  subject(:job_klass) do
+    Object.const_set(
+      Faker::Lorem.word.capitalize,
+      Class.new do
+        include SidekiqDelegate::Batch::Job
+      end
+    )
+  end
+
+  context 'server_actions' do
+    subject { job_klass.new }
+
+    it 'should "die quietly" when not valid_with_batch? to prevent frivolous retries' do
+      expect(subject).to receive(:valid_within_batch?).and_return(false)
+      expect(subject.logger).to receive(:warn).with("batch invalidated (dying quietly)")
+      expect(subject).not_to receive(:call_delegate)
+      subject.perform(double)
+    end
+
+    it 'should call_delegate if it is valid_within_batch?' do
+      expect(subject).to receive(:valid_within_batch?).and_return(true)
+      expect(subject).to receive(:call_delegate)
+      subject.perform(double)
+    end
+  end
+
+end

--- a/spec/extensions/method_spec.rb
+++ b/spec/extensions/method_spec.rb
@@ -1,0 +1,178 @@
+RSpec.describe Method do
+  let(:method_name) { Faker::Lorem.word.to_sym }
+  let(:return_value){ Faker::Lorem.word }
+  let(:mojule) { Object.const_set(Faker::Lorem.word.capitalize, Module.new) }
+
+  subject do
+    v = return_value
+    mojule.define_singleton_method(method_name) { v }
+    mojule.method(method_name)
+  end
+
+  it 'can be transformed into a Method::WithArgs by calling ".with_args"' do
+    expect(subject).to receive(:args=)
+    expect(subject).to receive(:named_args=)
+    expect(subject).to receive(:validate_args!)
+    expect(subject.with_args).to be_a(Method::WithArgs)
+  end
+
+  it 'can be called without arguments' do
+    expect(subject.with_args.call).to eq(return_value)
+  end
+
+  describe Method::WithArgs do
+    context 'is instantiable and usable' do
+      context 'when the method has required simple arguments' do
+        subject do
+          v = return_value
+          mojule.define_singleton_method(method_name) { |arg1, arg2, arg3| v }
+          mojule.method(method_name)
+        end
+
+        it 'should succeed when the right number of arguments are supplied' do
+          formed_subject = subject.with_args(1, 2, 3)
+          expect(formed_subject).to be_a(Method::WithArgs)
+          expect(formed_subject.args).to eq([1, 2, 3])
+        end
+
+        it 'should fail when the wrong number of arguments are supplied' do
+          expect {subject.with_args }.to raise_error(
+            ArgumentError,
+            %(
+              Method::WithArgs arguments don't match the method signature of the source method:\n\n
+              #{subject}\n\n
+              (NOTE: unbracketed hash arguments aren't supported)
+            ).split.join(' ')
+          )
+        end
+
+        it 'can be called' do
+          expect(subject.with_args(1, 2, 3).call).to eq(return_value)
+        end
+      end
+
+      context 'when the method has required named arguments' do
+        subject do
+          v = return_value
+          mojule.define_singleton_method(method_name) { |arg1:, arg2:, arg3:| v }
+          mojule.method(method_name)
+        end
+
+        it 'should succeed when the right number of arguments are supplied' do
+          formed_subject = subject.with_args(arg1: 1, arg2: 2, arg3: 3)
+          expect(formed_subject).to be_a(Method::WithArgs)
+          expect(formed_subject.named_args).to eq(
+            arg1: 1,
+            arg2: 2,
+            arg3: 3
+          )
+        end
+
+        it 'should fail when the wrong number of arguments are supplied' do
+          expect { subject.with_args }.to raise_error(
+            ArgumentError,
+            %(
+              Method::WithArgs arguments don't match the method signature of the source method:\n\n
+              #{subject}\n\n
+              (NOTE: unbracketed hash arguments aren't supported)
+            ).split.join(' ')
+          )
+        end
+
+        it 'can be called' do
+          expect(subject.with_args(arg1: 1, arg2: 2, arg3: 3).call).to eq(return_value)
+        end
+      end
+
+      context 'when the method has a combination of required simple and named arguments' do
+        subject do
+          v = return_value
+          mojule.define_singleton_method(method_name) { |arg1, arg2, arg3:, arg4:| v }
+          mojule.method(method_name)
+        end
+
+        it 'should succeed when the right number of arguments are supplied' do
+          formed_subject = subject.with_args(1, 2, arg3: 3, arg4: 4)
+          expect(formed_subject).to be_a(Method::WithArgs)
+          expect(formed_subject.args).to eq([1, 2])
+          expect(formed_subject.named_args).to eq(
+            arg3: 3,
+            arg4: 4
+          )
+        end
+
+        it 'should fail when the wrong number of arguments are supplied' do
+          expect { subject.with_args(1, arg4: 4) }.to raise_error(
+            ArgumentError,
+            %(
+              Method::WithArgs arguments don't match the method signature of the source method:\n\n
+              #{subject}\n\n
+              (NOTE: unbracketed hash arguments aren't supported)
+            ).split.join(' ')
+          )
+        end
+
+        it 'can be called' do
+          expect(subject.with_args(1, 2, arg3: 3, arg4: 4).call).to eq(return_value)
+        end
+      end
+
+      context 'when the method has splatted args and named args' do
+        subject do
+          v = return_value
+          mojule.define_singleton_method(method_name) { |*args, **nargs| v }
+          mojule.method(method_name)
+        end
+
+        it 'should succeed when args and named args are included' do
+          formed_subject = subject.with_args(1, 2, arg3: 3, arg4: 4)
+          expect(formed_subject).to be_a(Method::WithArgs)
+          expect(formed_subject.args).to eq([1, 2])
+          expect(formed_subject.named_args).to eq(
+            arg3: 3,
+            arg4: 4
+          )
+        end
+
+        it 'should succeed when args and named args are not included' do
+          formed_subject = subject.with_args
+          expect(formed_subject).to be_a(Method::WithArgs)
+          expect(formed_subject.args).to eq([])
+          expect(formed_subject.named_args).to eq({})
+        end
+      end
+    end
+
+    context 'has useful utility methods' do
+      subject do
+        mojule.define_singleton_method(method_name) {}
+        mojule.method(method_name).with_args
+      end
+
+      it "should determine equality based on the full set of parameters and it's source method" do
+        expect(subject).to eq(mojule.method(method_name).with_args)
+      end
+
+      it 'should be possible to convert to a hash with "to_h" and restore via via "Method::WithArgs.from_hash_splat"' do
+        h = subject.to_h
+        expect(h).to be_a(Hash)
+        expect(Method::WithArgs.from_hash_splat(**h)).to eq(subject)
+      end
+
+      it 'should provide facility to see the method from which it was derived' do
+        expect(subject.source).to eq(mojule.method(method_name))
+      end
+
+      it 'should make args and named args available' do
+        expect(subject.args).to be_a(Array)
+        expect(subject.named_args).to be_a(Hash)
+      end
+
+      it 'should be inspectable' do
+        expect(subject.inspect).to be_a(String)
+      end
+
+    end
+  end
+
+end

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -1,0 +1,235 @@
+RSpec.describe SidekiqDelegate::Job do
+  let(:klass_method) { Faker::Lorem.word.to_sym }
+  let(:delegate_klass) do
+    klass = Object.const_set(Faker::Lorem.word.capitalize, Class.new)
+    klass.define_singleton_method(klass_method) {}
+    klass
+  end
+  let(:delegate) { delegate_klass.method(klass_method).with_args }
+
+  subject(:job_klass) do
+    Object.const_set(
+      Faker::Lorem.word.capitalize,
+      Class.new do
+        include SidekiqDelegate::Job
+      end
+    )
+  end
+
+  context 'client_actions' do
+    it 'is able to enqueue a single job by calling perform_async' do
+      expect(job_klass).to receive(:validate_delegate!).with(delegate)
+
+      expect(job_klass).to receive(:client_push).with(
+        'class' => job_klass,
+        'queue' => 'default',
+        'args' => [delegate.to_h]
+      )
+
+      job_klass.perform_async(delegate)
+    end
+
+    it 'is able to enqueue a single job by calling perform_async (specifying a different queue)' do
+      q = double
+
+      expect(job_klass).to receive(:client_push).with(
+        'class' => job_klass,
+        'queue' => q,
+        'args' => [delegate.to_h]
+      )
+
+      job_klass.perform_async(delegate, queue: q)
+    end
+
+    it 'is able to enqueue a bulk set of jobs by calling perform_bulk' do
+      delegates = []
+      count = rand(100) + 10
+      count.times do
+        delegates << delegate
+      end
+
+      hashified_delegates = delegates.map do |mwa|
+        [mwa.to_h]
+      end
+
+      expect(job_klass).to receive(:validate_delegate!).exactly(count).times
+      expect(Sidekiq::Client).to receive(:push_bulk).with(
+        'class' => job_klass,
+        'queue' => 'default',
+        'args' => hashified_delegates
+      )
+
+      job_klass.perform_bulk(delegates)
+    end
+
+    it 'is able to enqueue a bulk set of jobs by calling perform_bulk (specifying a different queue)' do
+      delegates = []
+      count = rand(100) + 10
+      count.times do
+        delegates << delegate
+      end
+
+      q = double
+
+      hashified_delegates = delegates.map do |mwa|
+        [mwa.to_h]
+      end
+
+      expect(Sidekiq::Client).to receive(:push_bulk).with(
+        'class' => job_klass,
+        'queue' => q,
+        'args' => hashified_delegates
+      )
+
+      job_klass.perform_bulk(delegates, queue: q)
+    end
+
+    context 'having "perform_bulk" called with a block' do
+      it 'should yield each element of the argument list to the calling block, \
+      and validate and enqueue the modified value returned from the block' do
+        transforms = []
+        argument_list = (1..rand(100) + 50).to_a.each_with_object([]) do |i, ary|
+          h = { i.to_s => false }
+          transform = {i.to_s => true}
+          transforms << [transform]
+          expect(job_klass).to receive(:validate_delegate!).with(transform)
+          ary << h
+        end
+
+        expect(Sidekiq::Client).to receive(:push_bulk).with(
+          'class' => job_klass,
+          'queue' => 'default',
+          'args' => transforms
+        )
+
+        job_klass.perform_bulk(argument_list) do |arg_list_element|
+          key = arg_list_element.keys.first
+          arg_list_element[key] = true
+          arg_list_element
+        end
+      end
+
+      it 'should ignore nil values returned from the calling block' do
+        transforms = []
+        argument_list = (1..rand(100) + 50).to_a.each_with_object([]) do |i, ary|
+          h = { i.to_s => false }
+          transform = {i.to_s => true}
+
+          if i % 2 > 0
+            transforms << [transform]
+            expect(job_klass).to receive(:validate_delegate!).with(transform)
+          end
+
+          ary << h
+        end
+
+        expect(Sidekiq::Client).to receive(:push_bulk).with(
+          'class' => job_klass,
+          'queue' => 'default',
+          'args' => transforms
+        )
+
+        job_klass.perform_bulk(argument_list) do |arg_list_element|
+          key = arg_list_element.keys.first
+
+          if key.to_i % 2 == 0
+            nil
+          else
+            arg_list_element[key] = true
+            arg_list_element
+          end
+        end
+      end
+
+      it 'should flatten arrays of values returned from the calling block, validating each entry' do
+        transforms = []
+        argument_list = (1..rand(100) + 50).to_a.each_with_object([]) do |i, ary|
+          h = { i.to_s => false }
+          transform_1 = {i.to_s => true}
+          transform_2 = {i.to_s => nil}
+
+          transforms << [transform_1]
+
+          if i % 2 > 0
+            transforms << [transform_2]
+            expect(job_klass).to receive(:validate_delegate!).with(transform_2)
+          end
+
+          expect(job_klass).to receive(:validate_delegate!).with(transform_1)
+
+          ary << h
+        end
+
+        expect(Sidekiq::Client).to receive(:push_bulk).with(
+          'class' => job_klass,
+          'queue' => 'default',
+          'args' => transforms
+        )
+
+        job_klass.perform_bulk(argument_list) do |arg_list_element|
+          key = arg_list_element.keys.first
+          arg_list_element[key] = true
+
+          if key.to_i % 2 > 0
+            [arg_list_element, { key => nil }]
+          else
+            arg_list_element
+          end
+        end
+      end
+
+    end
+  end
+
+  context 'server_actions' do
+    subject { job_klass.new }
+
+    it 'should call_delegate when perform is called on an instance' do
+      options = Faker::Types::rb_hash
+      expect(subject).to receive(:call_delegate).with(options)
+      subject.perform(options)
+    end
+
+    it 'should log a begin and end message with information about the delegate and "call" it' do
+      options = double
+      expect(subject).to receive(:delegate_method).with(options).and_return(delegate)
+      expect(subject.logger).to receive(:info).with("#{delegate.inspect} begin")
+      expect(delegate).to receive(:call)
+      expect(subject.logger).to receive(:info).with("#{delegate.inspect} end")
+
+      subject.perform(options)
+    end
+
+    context 'validating job options' do
+      it 'should die with a no-op and log a descriptive error message if the job options are invalid' do
+        options = double
+        error = SidekiqDelegate::Error::DelegateError.new
+        expect(subject).to receive(:delegate_method).with(options).and_raise(error)
+        expect(subject.logger).to receive(:error).with("NON-RETRYABLE: #{error.inspect} \
+( NOTE: This job is misconfigured. Use perform_bulk or perform_async to ensure job is valid during enqueue )")
+        expect(subject.logger).to receive(:info).with("#{nil.inspect} end")
+
+        subject.perform(options)
+      end
+
+      it 'job options should not be valid if they are not a hash' do
+        options = double
+        expect(subject.logger).to receive(:error)
+        subject.perform(options)
+      end
+
+      it "job options should not be valid if the options hash doesn't match the delegate structure" do
+        options = Faker::Types.rb_hash
+        expect(subject.logger).to receive(:error)
+        subject.perform(options)
+      end
+
+      it "job options should not be valid if the options hash doesn't match the delegate method signature" do
+        options = delegate.to_h.merge(args: [double])
+        expect(subject.logger).to receive(:error)
+        subject.perform(options)
+      end
+    end
+  end
+
+end

--- a/spec/sidekiq_delegate_spec.rb
+++ b/spec/sidekiq_delegate_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe SidekiqDelegate do
   it "has a version number" do
     expect(SidekiqDelegate::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "sidekiq_delegate"
+require 'faker'
+require 'byebug'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe SidekiqDelegate::Validator do
+  let(:klass_method) { Faker::Lorem.word.to_sym }
+  let(:instance_method) { Faker::Lorem.word.to_sym }
+  let(:delegate_klass) do
+    delegate_klass = Object.const_set(Faker::Lorem.word.capitalize, Class.new)
+    delegate_klass.define_singleton_method(klass_method) {}
+    delegate_klass.define_method(instance_method) {}
+    delegate_klass
+  end
+  let(:delegate) { delegate_klass.method(klass_method).with_args }
+
+  it "should be able to use it's class methods as valid sidekiq delegates when transformed with '.with_args'" do
+    validation = begin
+      subject.validate_delegate!(delegate)
+    rescue => e
+      e
+    end
+
+    expect(validation).not_to be_an_instance_of(SidekiqDelegate::Error::DelegateError)
+  end
+
+  it "should not be able to use it's class methods as sidekiq delegates untransformed with '.with_args'" do
+    validation = begin
+      subject.validate_delegate!(
+        delegate_klass.method(klass_method)
+      )
+    rescue => e
+      e
+    end
+
+    expect(validation).to be_an_instance_of(SidekiqDelegate::Error::DelegateError)
+  end
+
+  it "should not be able to use it's instance methods as sidekiq delegates" do
+    validation_1 = begin
+      subject.validate_delegate!(
+        delegate_klass.new.method(instance_method)
+      )
+    rescue => e
+      e
+    end
+
+    validation_2 = begin
+      subject.validate_delegate!(
+        delegate_klass.new.method(instance_method).with_args
+      )
+    rescue => e
+      e
+    end
+
+    expect(validation_1).to be_an_instance_of(SidekiqDelegate::Error::DelegateError)
+    expect(validation_2).to be_an_instance_of(SidekiqDelegate::Error::DelegateError)
+  end
+
+end


### PR DESCRIPTION
- Modified Method::WithArgs module to support splatted arguments, and privatized what should be non-public methods
- Modified SidekiqDelegate::Job#perform_bulk to allow for yield to return nil or an array of Method::WithArgs, adding flexibility when bulk enqueueing using the "single loop" functionality.
- Removed unnecessary complexity in SidekiqDelegate::Validator by consolidating the validation into a single (non-redundant) method: _validate_delegate!_
- Modified sidekiq gem version reqs. to allow for broader range of versions.